### PR TITLE
Add non-active streamer list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 result*
+.envrc
+.direnv/

--- a/README.md
+++ b/README.md
@@ -65,9 +65,10 @@ A list of active (see [active](#active) for how we define active) declarative pr
 
 ##### Active
 
-The term "active" considers two components: frequency and consistency. The list should consider streamers with a
-good frequency (>=1 stream per month) but consistency is important for many folks. Look for schedules or links to
-a schedule for consistent streamers.
+The term "active" considers two components: frequency and consistency. The list
+should consider streamers with a good frequency (>=1 stream per month) but
+consistency is important for many folks. Look for schedules or links to a
+schedule for consistent streamers.
 
 ##### Contributing
 
@@ -89,4 +90,14 @@ Add your stream to [streamers.json](streamers.json). All fields are required.
 }
 ```
 
-Submit a PR with your changes to `streamers.json` and the CI will autogenerate a `README.md` when it hits master.
+Submit a PR with your changes to `streamers.json` and the CI will autogenerate
+a `README.md` when it hits master.
+
+#### Previously Active Streams
+
+Here is a list of previously active streamers. Please open up a PR to make
+yourself active again
+
+<!-- generated:not-active-start -->
+...
+<!-- generated:not-active-end -->

--- a/generate-readme/Main.hs
+++ b/generate-readme/Main.hs
@@ -28,11 +28,19 @@ startFence = "<!-- generated:start -->"
 endFence :: String
 endFence = "<!-- generated:end -->"
 
-readmeP :: Parser (String, String)
+startNotActiveFence :: String
+startNotActiveFence = "<!-- generated:not-active-start -->"
+
+endNotActiveFence :: String
+endNotActiveFence = "<!-- generated:not-active-end -->"
+
+readmeP :: Parser (String, String, String)
 readmeP =
-  (,)
+  (,,)
     <$> manyTill anyChar (string startFence)
     <* manyTill anyChar (string endFence)
+    <*> manyTill anyChar (string startNotActiveFence)
+    <* manyTill anyChar (string endNotActiveFence)
     <*> manyTill anyChar eof
 
 streamer :: Streamer -> String
@@ -45,26 +53,32 @@ streamer s =
       "  - Schedule: " <> schedule s
     ]
 
-generateReadme :: (String, String) -> [Streamer] -> String
-generateReadme (before, after) ss =
+generateReadme :: (String, String, String) -> [Streamer] -> [Streamer] -> String
+generateReadme (before, middle, last) streamers notActiveStreamers =
   intercalate
     "\n"
     [ before <> startFence <> "\n",
-      intercalate "\n" $ fmap streamer ss,
-      "\n" <> endFence <> after
+      intercalate "\n" $ streamer <$> streamers,
+      "\n" <> endFence,
+      middle,
+      startNotActiveFence <> "\n",
+      intercalate "\n" $ streamer <$> notActiveStreamers,
+      "\n" <> endNotActiveFence,
+      last
     ]
 
 readme :: String
-readme = "Usage: ./generate-readme README.md streamers.json"
+readme = "Usage: ./generate-readme README.md streamers.json not-currently-active.json"
 
 main :: IO ()
 main = do
   args <- getArgs
   case args of
-    [readmeFileName, streamerFileName] -> do
+    [readmeFileName, streamerFileName, notActiveStreamerFileName] -> do
       contents <- first show <$> parseFromFile readmeP readmeFileName
       streamers <- (fmap . fmap) (sortOn (fmap toLower . name)) $ eitherDecodeFileStrict streamerFileName
-      case generateReadme <$> contents <*> streamers of
+      notActiveStreamers <- (fmap . fmap) (sortOn (fmap toLower . name)) $ eitherDecodeFileStrict notActiveStreamerFileName
+      case generateReadme <$> contents <*> streamers <*> notActiveStreamers of
         Right newContents -> putStr newContents
         Left err -> putStrLn err
     _ -> putStrLn readme

--- a/not-currently-active.json
+++ b/not-currently-active.json
@@ -1,0 +1,65 @@
+[
+  {
+    "name": "avh4",
+    "channel": "https://www.twitch.tv/avh4",
+    "speaking": ["EN"],
+    "languages": ["Elm", "Haskell"],
+    "schedule": "[Various times Tu/Th/Su](https://twitter.com/avh4/status/1333478708934369282)"
+  },
+  {
+    "name": "junxan",
+    "channel": "https://twitch.tv/junxan",
+    "speaking": ["EN"],
+    "languages": ["Purescript", "Haskell"],
+    "schedule": "Tuesdays, Thursdays at 8 PM, Saturdays at 4 PM UTC+1 (full schedule [on twitch](https://www.twitch.tv/junxan/schedule))"
+  },
+  {
+    "name": "kerckhove_ts",
+    "channel": "https://www.twitch.tv/kerckhove_ts",
+    "speaking": ["EN"],
+    "languages": ["Haskell"],
+    "schedule": "Streams announced on [Twitter](https://twitter.com/kerckhove_ts)"
+  },
+  {
+    "name": "lowderdev",
+    "channel": "https://www.twitch.tv/lowderdev",
+    "speaking": ["EN"],
+    "languages": ["Haskell"],
+    "schedule": "Wednesday and Saturday at 8pm - 10pm(ish) US Central Time (GMT-5)"
+  },
+  {
+    "name": "myShoggoth",
+    "channel": "https://www.twitch.tv/myshoggoth",
+    "speaking": ["EN"],
+    "languages": ["Haskell"],
+    "schedule": "Sunday, Monday, and Thursday at 8:30 PM PST"
+  },
+  {
+    "name": "quinndougherty92",
+    "channel": "https://www.twitch.tv/quinndougherty92",
+    "speaking": ["EN"],
+    "languages": ["Coq"],
+    "schedule": "Sundays 2-5 PM EST"
+  },
+  {
+    "name": "totbwf",
+    "channel": "https://www.twitch.tv/totbwf",
+    "speaking": ["EN"],
+    "languages": ["Agda", "Pen and Paper"],
+    "schedule": "Mon, Thurs at 5 PM PST"
+  },
+  {
+    "name": "tritlo",
+    "channel": "https://www.twitch.tv/tritlo",
+    "speaking": ["EN"],
+    "languages": ["Haskell"],
+    "schedule": "Streams announced on [Twitter](https://twitter.com/tritlo)"
+  },
+  {
+    "name": "tscholak",
+    "channel": "https://www.twitch.tv/tscholak",
+    "speaking": ["EN"],
+    "languages": ["Haskell"],
+    "schedule": "Streams announced on [Twitter](https://twitter.com/tscholak)"
+  }
+]

--- a/streamers.json
+++ b/streamers.json
@@ -7,17 +7,10 @@
     "schedule": "Tue at 8:10pm EST - [full schedule on twitch](https://www.twitch.tv/agentultra/schedule)"
   },
   {
-    "name": "avh4",
-    "channel": "https://www.twitch.tv/avh4",
-    "speaking": ["EN"],
-    "languages": ["Elm", "Haskell"],
-    "schedule": "[Various times Tu/Th/Su](https://twitter.com/avh4/status/1333478708934369282)"
-  },
-  {
     "name": "chiroptical",
     "channel": "https://twitch.tv/chiroptical",
     "speaking": ["EN"],
-    "languages": ["**Haskell**", "Kotlin"],
+    "languages": ["**Haskell**", "Rust", "TypeScript"],
     "schedule": "Sun 9:00-11:00 AM EST"
   },
   {
@@ -39,62 +32,6 @@
     "speaking": ["EN"],
     "languages": ["Idris"],
     "schedule": "Wed and Fri between 2 and 6pm UTC+0"
-  },
-  {
-    "name": "junxan",
-    "channel": "https://twitch.tv/junxan",
-    "speaking": ["EN"],
-    "languages": ["Purescript", "Haskell"],
-    "schedule": "Tuesdays, Thursdays at 8 PM, Saturdays at 4 PM UTC+1 (full schedule [on twitch](https://www.twitch.tv/junxan/schedule))"
-  },
-  {
-    "name": "kerckhove_ts",
-    "channel": "https://www.twitch.tv/kerckhove_ts",
-    "speaking": ["EN"],
-    "languages": ["Haskell"],
-    "schedule": "Streams announced on [Twitter](https://twitter.com/kerckhove_ts)"
-  },
-  {
-    "name": "lowderdev",
-    "channel": "https://www.twitch.tv/lowderdev",
-    "speaking": ["EN"],
-    "languages": ["Haskell"],
-    "schedule": "Wednesday and Saturday at 8pm - 10pm(ish) US Central Time (GMT-5)"
-  },
-  {
-    "name": "myShoggoth",
-    "channel": "https://www.twitch.tv/myshoggoth",
-    "speaking": ["EN"],
-    "languages": ["Haskell"],
-    "schedule": "Sunday, Monday, and Thursday at 8:30 PM PST"
-  },
-  {
-    "name": "quinndougherty92",
-    "channel": "https://www.twitch.tv/quinndougherty92",
-    "speaking": ["EN"],
-    "languages": ["Coq"],
-    "schedule": "Sundays 2-5 PM EST"
-  },
-  {
-    "name": "totbwf",
-    "channel": "https://www.twitch.tv/totbwf",
-    "speaking": ["EN"],
-    "languages": ["Agda", "Pen and Paper"],
-    "schedule": "Mon, Thurs at 5 PM PST"
-  },
-  {
-    "name": "tritlo",
-    "channel": "https://www.twitch.tv/tritlo",
-    "speaking": ["EN"],
-    "languages": ["Haskell"],
-    "schedule": "Streams announced on [Twitter](https://twitter.com/tritlo)"
-  },
-  {
-    "name": "tscholak",
-    "channel": "https://www.twitch.tv/tscholak",
-    "speaking": ["EN"],
-    "languages": ["Haskell"],
-    "schedule": "Streams announced on [Twitter](https://twitter.com/tscholak)"
   },
   {
     "name": "klarkc",


### PR DESCRIPTION
1. Look up all the current streamers and determine if that had a recent stream, if they didn't move them to `not-currently-active.json`
2. Extend the generate-readme script to support the non-active streamer list