### PR TITLE
Add nicuveo

### DIFF
--- a/streamers.json
+++ b/streamers.json
@@ -12,5 +12,12 @@
     "speaking": ["EN"],
     "languages": ["Unison", "Erlang", "Haskell"],
     "schedule": "Mon-Fri 7:45-8:30 AM EST"
+  },
+  {
+    "name": "nicuveo",
+    "channel": "https://twitch.tv/nicuveo",
+    "speaking": ["EN"],
+    "languages": ["Haskell"],
+    "schedule": "Tuesday and Thursday at 8PM Dublin time"
   }
 ]


### PR DESCRIPTION
As discussed on Bluesky, here's my entry.

I wasn't sure how to list my schedule, since Ireland doesn't have a fixed timezone: it is using IST (Irish Standard Time, UTC+1) in the summer and GMT (UTC+0) in the winter. Should i add a link to my twitch schedule instead, perhaps?